### PR TITLE
ACD-296: Test 404 handling

### DIFF
--- a/steps/case_detail_steps.js
+++ b/steps/case_detail_steps.js
@@ -24,6 +24,10 @@ export class CaseDetailSteps {
     await this.caseSummaryPage.goto(URN)
   }
 
+  async whenIVisitTheSummaryPageOfANonexistentCase() {
+    await this.caseSummaryPage.goto("NOT_A_REAL_CASE")
+  }
+
   async whenIVisitTheSummaryPageOfAnUnlinkedCase() {
     await this.whenIVisitTheSummaryPageOfACase()
     await expect(this.page.locator('body')).toContainText('Not linked')

--- a/tests/errors.spec.js
+++ b/tests/errors.spec.js
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test'
+import { SignInSteps } from '../steps/sign_in_steps'
+import { GenericSteps } from '../steps/generic_steps'
+import { CaseDetailSteps } from '../steps/case_detail_steps'
+
+test.describe('Errors', () => {
+  let signInSteps
+  let caseDetailSteps
+  let genericSteps
+
+  test.beforeEach(async ({ page }) => {
+    signInSteps = new SignInSteps(page)
+    caseDetailSteps = new CaseDetailSteps(page)
+    genericSteps = new GenericSteps(page)
+  })
+
+  test('404 errors are handled appropriately', async () => {
+    await signInSteps.givenIAmSignedInAsACaseworker();
+    await caseDetailSteps.whenIVisitTheSummaryPageOfANonexistentCase();
+    await genericSteps.thenIShouldSeeText(
+      'There was a problem getting the information you requested. ' +
+      'If this problem persists, please contact the IT Helpdesk on 0800 9175148.'
+    )
+  })
+})


### PR DESCRIPTION
We already test validation error cases when searching or linking, and testing CDA/Mock system errors is extremely hard. So this just tests the CDA/Mock 404 error path.