### PR TITLE
ACD-907: Switch to appeals v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,6 @@ services:
       COURT_DATA_ADAPTOR_API_SECRET: test-app-secret
       CASEWORKER_PASSWORD: caseworker-password
       MANAGER_PASSWORD: manager-password
-      SHOW_APPEALS: 'true'
+      APPEALS_V2: 'true'
     depends_on:
       - acd-db-services

--- a/steps/case_detail_steps.js
+++ b/steps/case_detail_steps.js
@@ -59,9 +59,6 @@ export class CaseDetailSteps {
   }
 
   async andIUnlinkTheDefendant() {
-    await this.page.locator('summary:has-text("Remove link to court data")') // Expand the summary section
-              .click();
-
     await this.page.getByLabel('Reason for unlinking')
               .selectOption('1')
 


### PR DESCRIPTION
With the Appeals v2 FF set, you don't need to click the summary element to see the unlink form.